### PR TITLE
Use full stop to enable mid-word prefixes

### DIFF
--- a/html-entities.code-snippets
+++ b/html-entities.code-snippets
@@ -1,17 +1,24 @@
 {
-	// Place your global snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
-	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
-	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
-	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
-	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
-	// Placeholders with the same ids are connected.
-	// Example:
+	// HTML entities often need to be inserted mid-word,
+	// but most snippet prefixes won't work mid-word.
+	// To enable a snippet prefix to trigger correctly,
+	// we start these prefixes with a full stop, which
+	// signals to VS Code that we're not typing the word,
+	// but something new, making it recognisable as a prefix.
 	"Non-breaking space": {
 		"scope": "",
-		"prefix": "nb",
+		"prefix": ".nb",
 		"body": [
 			"&nbsp;"
 		],
 		"description": "Insert a non-breaking space"
+	},
+	"Discretionary (soft) hyphen": {
+		"scope": "",
+		"prefix": ".sh",
+		"body": [
+			"&shy;"
+		],
+		"description": "Insert a discretionary or soft hyphen"
 	}
 }


### PR DESCRIPTION
HTML entities often need to be inserted mid-word, but most snippet prefixes won't work mid-word, because VS Code thinks we're still typing the word, and doesn't recognise that we're typing a snippet prefix.

To enable a snippet prefix to trigger correctly, we start these prefixes with a full stop, which signals to VS Code that we're not typing the word, but something new, making it recognisable as a prefix.