### PR TITLE
Use hashes in entity prefixes

### DIFF
--- a/html-entities.code-snippets
+++ b/html-entities.code-snippets
@@ -2,12 +2,12 @@
 	// HTML entities often need to be inserted mid-word,
 	// but most snippet prefixes won't work mid-word.
 	// To enable a snippet prefix to trigger correctly,
-	// we start these prefixes with a full stop, which
+	// we start these prefixes with a hash (#), which
 	// signals to VS Code that we're not typing the word,
 	// but something new, making it recognisable as a prefix.
 	"Non-breaking space": {
 		"scope": "",
-		"prefix": ".nb",
+		"prefix": "#nb",
 		"body": [
 			"&nbsp;"
 		],
@@ -15,7 +15,7 @@
 	},
 	"Discretionary (soft) hyphen": {
 		"scope": "",
-		"prefix": ".sh",
+		"prefix": "#sh",
 		"body": [
 			"&shy;"
 		],


### PR DESCRIPTION
@LouiseSteward @LaurenEllwood This is the change I mentioned this morning: using a hash to start the entity prefixes, so that they work mid-word. Any objections to merging this in, or alternative suggestions?

As I mentioned, I tried using a full stop, but then when you type a full stop you get a suggestions popup, and pressing enter selects the first suggestion – which makes this unworkable at the ends of paragraphs.