### PR TITLE
Updates to JS and markdown snippets

### DIFF
--- a/javascript-std.code-snippets
+++ b/javascript-std.code-snippets
@@ -10,6 +10,14 @@
         ],
         "description": "Insert a console.log statement"
     },
+    "Debug to console (Std)": {
+        "scope": "javascript",
+        "prefix": "debug",
+        "body": [
+            "console.debug(${1:'$0'})"
+        ],
+        "description": "Insert a console.debug statement"
+    },
 	"For loop (Std)": {
 		"scope": "javascript",
 		"prefix": "for",
@@ -37,7 +45,7 @@
         "body": [
             "function ${1:name}(${2:parameter}) {",
             "  'use strict'",
-            "  $0"
+            "  $0",
             "}"
         ],
         "description": "Insert a function"

--- a/javascript.code-snippets
+++ b/javascript.code-snippets
@@ -1,8 +1,8 @@
 {
-    // Please only create JSLint-friendly Javascript snippets.
-    // JSLint is strict and painful but great for beginners
-    // who need its constraints to learn and develop good habits.
-    "Log to console": {
+    // These are JS Lint Javascript snippets.
+    // JSLint is strict and painful but good for beginners
+    // who will learn a lot from its constraints.
+    "Log to console (JS Lint)": {
         "scope": "javascript",
         "prefix": "log",
         "body": [
@@ -10,7 +10,15 @@
         ],
         "description": "Insert a console.log statement"
     },
-	"For loop": {
+    "Debug to console (JS Lint)": {
+        "scope": "javascript",
+        "prefix": "debug",
+        "body": [
+            "console.debug(${1:'$0'});"
+        ],
+        "description": "Insert a console.debug statement"
+    },
+	"For loop (JS Lint)": {
 		"scope": "javascript",
 		"prefix": "for",
 		"body": [
@@ -21,7 +29,7 @@
 		],
 		"description": "Insert a for loop"
 	},
-    "forEach": {
+    "forEach (JS Lint)": {
         "scope": "javascript",
         "prefix": "foreach",
         "body": [
@@ -31,18 +39,18 @@
         ],
         "description": "Insert a forEach statement"
     },
-    "Function": {
+    "Function (JS Lint)": {
         "scope": "javascript",
         "prefix": "fn",
         "body": [
             "function ${1:name}(${2:parameter}) {",
             "    'use strict';",
-            "    $0"
+            "    $0",
             "}"
         ],
         "description": "Insert a function"
     },
-    "Use strict": {
+    "Use strict (JS Lint)": {
         "scope": "javascript",
         "prefix": "strict",
         "body": [
@@ -50,7 +58,7 @@
         ],
         "description": "Insert 'use strict';"
     },
-    "JS Lint directives": {
+    "JS Lint directives (JS Lint)": {
         "scope": "javascript",
         "prefix": "jslint",
         "body": [

--- a/markdown.code-snippets
+++ b/markdown.code-snippets
@@ -44,7 +44,26 @@
 			""
 		],
 		"description": "Inserts dynamic index tag"
+	},
+	"first-paragraph tag": {
+		"scope": "markdown",
+		"prefix": [
+			"fst"
+		],
+		"body": [
+			"{:.first}$0"
+		],
+		"description": "Inserts a {:.first} tag"
+	},
+	"sidenote tag": {
+		"scope": "markdown",
+		"prefix": [
+			"snt"
+		],
+		"body": [
+			"{:.sidenote}",
+			"$0"
+		],
+		"description": "Inserts a {:.sidenote} class tag"
 	}
-
-
 }


### PR DESCRIPTION
- Better distinguish and duplicate JS Lint and Stadnard JS snippets (we're phasing out JS Lint, but might need those around for maintaining/extending old codebases)
- Add markdown snippets for `{:.first} and `{.sidenote}`.
